### PR TITLE
ISSUE 1533: Fix --config argument description

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -471,7 +471,7 @@ def target_version_option_callback(
     ),
     is_eager=True,
     callback=read_pyproject_toml,
-    help="Read configuration from PATH.",
+    help="Read configuration from FILE.",
 )
 @click.pass_context
 def main(


### PR DESCRIPTION
Closes #1533

Change --config argument description to "Read configuration from FILE."
Reason: It is unclear  "--help" view for "--config" argument which looks like:
"--config FILE                   Read configuration from PATH.". It is unclear because we pass "FILE" as argument value, but the configuration will be read from the "PATH".
The "--config FILE                   Read configuration from FILE." description is more clear.